### PR TITLE
Add team labels when CODEOWNERS requests review from a team

### DIFF
--- a/src/main/java/org/keycloak/gh/bot/AddAreaLabelToBugs.java
+++ b/src/main/java/org/keycloak/gh/bot/AddAreaLabelToBugs.java
@@ -19,7 +19,7 @@ public class AddAreaLabelToBugs {
         if (Labels.hasLabel(issue, Labels.KIND_BUG)) {
             String areaLabel = IssueParser.getAreaFromBody(issuePayload.getIssue().getBody());
             if (areaLabel != null) {
-                Labels.addArea(issue, areaLabel);
+                Labels.addLabelIfExists(issue, areaLabel);
             }
         }
     }

--- a/src/main/java/org/keycloak/gh/bot/AddTeamLabelToPRs.java
+++ b/src/main/java/org/keycloak/gh/bot/AddTeamLabelToPRs.java
@@ -1,0 +1,28 @@
+package org.keycloak.gh.bot;
+
+import io.quarkiverse.githubapp.event.PullRequest;
+import org.keycloak.gh.bot.utils.Labels;
+import org.kohsuke.github.GHEventPayload;
+import org.kohsuke.github.GHTeam;
+
+import java.io.IOException;
+
+public class AddTeamLabelToPRs {
+
+    private String MAINTAINERS_TEAM_SUFFIX = "-maintainers";
+
+    void onOpen(@PullRequest.ReviewRequested GHEventPayload.PullRequest pullRequest) throws IOException {
+        for (GHTeam team : pullRequest.getPullRequest().getRequestedTeams()) {
+            String teamName = team.getName();
+            if (teamName.endsWith(MAINTAINERS_TEAM_SUFFIX)) {
+                teamName = teamName.substring(0, teamName.length() - MAINTAINERS_TEAM_SUFFIX.length());
+            }
+
+            if (!teamName.equals("maintainers")) {
+                Labels.addLabelIfExists(pullRequest.getPullRequest(), "team/" + teamName);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/keycloak/gh/bot/utils/Labels.java
+++ b/src/main/java/org/keycloak/gh/bot/utils/Labels.java
@@ -1,9 +1,9 @@
 package org.keycloak.gh.bot.utils;
 
 import org.jboss.logging.Logger;
-import org.keycloak.gh.bot.AddAreaLabelToBugs;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.PagedIterator;
 
@@ -25,13 +25,13 @@ public class Labels {
         return issue.getLabels().stream().filter(l -> l.getName().equals(label)).findFirst().isPresent();
     }
 
-    public static void addArea(GHIssue issue, String areaLabel) throws IOException {
+    public static void addLabelIfExists(GHIssue issue, String areaLabel) throws IOException {
         if (!hasLabel(issue, areaLabel)) {
             if (hasLabel(issue.getRepository(), areaLabel)) {
                 issue.addLabels(areaLabel);
-                logger.infov("Added label {0} to issue {1}", areaLabel, issue.getHtmlUrl());
+                logger.infov("Added label {0} to {1}", areaLabel, issue.getHtmlUrl());
             } else {
-                logger.errorv("Label {0} not found for issue {1}", areaLabel, issue.getHtmlUrl());
+                logger.errorv("Label {0} not found for {1}", areaLabel, issue.getHtmlUrl());
             }
         }
     }


### PR DESCRIPTION
- Make bot reporting on PRs with flaky tests less intrusive
- Add team labels when CODEOWNERS requests review from a team
