### PR TITLE
Reduce the amount of logging in GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
         distribution: temurin
         cache: maven
     - name: Test
-      run: mvn package -Dquarkus.native.container-build=true
+      run: ./mvnw -B package -Dquarkus.native.container-build=true


### PR DESCRIPTION
This makes is simpler to read the logs. It also ensures to pick the right version of Maven as specified in the Maven wrapper.