### PR TITLE
Bot creating duplicated GitHub issues in keycloak-private when receiving e-mails from secalert

### DIFF
--- a/src/main/java/org/keycloak/gh/bot/security/command/SecAlertCommand.java
+++ b/src/main/java/org/keycloak/gh/bot/security/command/SecAlertCommand.java
@@ -18,9 +18,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * Sends emails to SecAlert. Creates a new thread when no SecAlert-Thread-ID exists, otherwise replies on the existing thread.
+ * Sends emails to SecAlert. Targets secalert.email.to for the initial outreach and secalert.email.reply-to once a
+ * SecAlert-Thread-ID (captured from the reply address) is recorded on the issue.
  */
-@Command(name = "secalert", description = "Sends a new email or reply to SecAlert and tracks the thread ID")
+@Command(name = "secalert", description = "Sends a new email or reply to SecAlert and tracks the reply thread ID")
 public class SecAlertCommand extends CommandParser implements BotCommand {
 
     private static final Logger LOGGER = Logger.getLogger(SecAlertCommand.class);
@@ -30,8 +31,11 @@ public class SecAlertCommand extends CommandParser implements BotCommand {
     @Inject
     MailSender mailSender;
 
-    @ConfigProperty(name = "email.sender.secalert")
-    String secAlertEmail;
+    @ConfigProperty(name = "secalert.email.to")
+    String secAlertTo;
+
+    @ConfigProperty(name = "secalert.email.reply-to")
+    String secAlertReplyTo;
 
     @ConfigProperty(name = "google.group.target")
     String targetGroup;
@@ -59,17 +63,16 @@ public class SecAlertCommand extends CommandParser implements BotCommand {
             return;
         }
 
-        LOGGER.infof("Sending new SecAlert email for issue #%d, subject: %s", payload.getIssue().getNumber(), subject);
+        GHIssue issue = payload.getIssue();
+        String taggedSubject = subject + " - " + Constants.GHI_ISSUE_PREFIX + issue.getNumber();
 
-        Optional<String> threadId = mailSender.sendNewEmail(secAlertEmail, targetGroup, subject, body);
+        LOGGER.infof("Sending new SecAlert email for issue #%d, subject: %s", issue.getNumber(), taggedSubject);
+
+        Optional<String> threadId = mailSender.sendNewEmail(secAlertTo, targetGroup, taggedSubject, body);
         if (threadId.isEmpty()) {
             fail(payload, "Failed to send email to SecAlert via Gmail API.");
             return;
         }
-
-        String marker = Constants.SECALERT_THREAD_ID_PREFIX + " " + threadId.get();
-        GHIssue issue = payload.getIssue();
-        issue.comment("SecAlert email sent. " + marker);
 
         Set<String> currentLabels = issue.getLabels().stream().map(GHLabel::getName).collect(Collectors.toSet());
         if (currentLabels.contains(Status.TRIAGE.toLabel())) {
@@ -78,7 +81,7 @@ public class SecAlertCommand extends CommandParser implements BotCommand {
         issue.addLabels(Status.CVE_REQUEST.toLabel());
 
         String title = issue.getTitle();
-        if (!title.startsWith(Constants.CVE_TBD_PREFIX)) {
+        if (title != null && !title.startsWith(Constants.CVE_TBD_PREFIX)) {
             issue.setTitle(Constants.CVE_TBD_PREFIX + " " + title);
         }
         success(payload);
@@ -87,7 +90,7 @@ public class SecAlertCommand extends CommandParser implements BotCommand {
     private void replyToExistingThread(GHEventPayload.IssueComment payload, String threadId, String body) throws IOException {
         LOGGER.infof("Replying to existing SecAlert thread %s for issue #%d", threadId, payload.getIssue().getNumber());
 
-        if (mailSender.sendThreadedEmail(threadId, secAlertEmail, targetGroup, body)) {
+        if (mailSender.sendThreadedEmail(threadId, secAlertReplyTo, targetGroup, body)) {
             success(payload);
         } else {
             fail(payload, "Failed to send reply to SecAlert thread " + threadId + ".");

--- a/src/main/java/org/keycloak/gh/bot/security/common/Constants.java
+++ b/src/main/java/org/keycloak/gh/bot/security/common/Constants.java
@@ -6,6 +6,9 @@ public final class Constants {
 
     public static final Pattern CVE_PATTERN = Pattern.compile("CVE-\\d{4}-\\d+");
 
+    public static final String GHI_ISSUE_PREFIX = "#GHI-";
+    public static final Pattern GHI_ISSUE_PATTERN = Pattern.compile("#GHI-(\\d{1,9})");
+
     public static final String GMAIL_THREAD_ID_PREFIX = "**Gmail-Thread-ID:**";
     public static final String SECALERT_THREAD_ID_PREFIX = "**SecAlert-Thread-ID:**";
     public static final String CVE_TBD_PREFIX = "[CVE-TBD]";

--- a/src/main/java/org/keycloak/gh/bot/security/email/MailProcessor.java
+++ b/src/main/java/org/keycloak/gh/bot/security/email/MailProcessor.java
@@ -14,6 +14,7 @@ import org.keycloak.gh.bot.labels.Status;
 import org.keycloak.gh.bot.security.common.Constants;
 import org.keycloak.gh.bot.utils.Labels;
 import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHRepository;
@@ -23,9 +24,11 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 @ApplicationScoped
 public class MailProcessor {
@@ -43,8 +46,8 @@ public class MailProcessor {
     @ConfigProperty(name = "repository.privateRepository")
     String repositoryName;
 
-    @ConfigProperty(name = "email.sender.secalert")
-    String secAlertEmail;
+    @ConfigProperty(name = "secalert.email.reply-to")
+    String secAlertReplyTo;
 
     @Inject
     GmailAdapter gmail;
@@ -59,6 +62,11 @@ public class MailProcessor {
 
     private final Cache<String, Integer> issueCache = Caffeine.newBuilder()
             .maximumSize(1000)
+            .expireAfterWrite(Duration.ofDays(7))
+            .build();
+
+    private final Cache<Integer, Boolean> secAlertThreadIdCache = Caffeine.newBuilder()
+            .maximumSize(500)
             .expireAfterWrite(Duration.ofDays(7))
             .build();
 
@@ -100,15 +108,19 @@ public class MailProcessor {
             var msg = gmail.getMessage(msgSummary.getId());
             var headers = gmail.getHeadersMap(msg);
             var from = headers.getOrDefault("From", "");
+            var replyTo = headers.getOrDefault("Reply-To", "");
 
-            if (isFromBot(from) || !isValidGroupMessage(headers)) {
+            boolean fromSecAlert = isFromSecAlert(from, replyTo);
+
+            if (isFromBot(from) || (!fromSecAlert && !isValidGroupMessage(headers))) {
                 gmail.markAsRead(msgSummary.getId());
                 return;
             }
 
             var threadId = msg.getThreadId();
             var messageId = headers.getOrDefault("Message-ID", "").replaceAll("^<|>$", "");
-            var subject = normalizeSubject(headers.getOrDefault("Subject", "(No Subject)").trim());
+            var rawSubject = headers.getOrDefault("Subject", "(No Subject)").trim();
+            var subject = normalizeSubject(rawSubject);
 
             var body = bodySanitizer.sanitize(gmail.getBody(msg)).orElse("(No content)");
             var attachments = gmail.getAttachments(msg);
@@ -117,8 +129,10 @@ public class MailProcessor {
 
             var issueOpt = resolveIssue(github, repository, threadId);
 
-            if (issueOpt.isEmpty() && isFromSecAlert(from)) {
-                issueOpt = resolveIssueBySecAlertThread(github, repository, threadId);
+            if (issueOpt.isEmpty() && fromSecAlert) {
+                issueOpt = resolveIssueByGhiTag(repository, rawSubject)
+                        .or(() -> resolveIssueBySecAlertThreadId(github, repository, threadId));
+                issueOpt.ifPresent(issue -> issueCache.put(threadId, issue.getNumber()));
             }
 
             if (issueOpt.isPresent()) {
@@ -129,8 +143,9 @@ public class MailProcessor {
                 }
                 appendComment(issue, from, body, attachmentSection);
 
-                if (isFromSecAlert(from)) {
+                if (fromSecAlert) {
                     applyCveIdFromSecAlert(issue, subject, body);
+                    recordSecAlertThreadIdIfMissing(issue, threadId);
                 }
             } else {
                 var newIssue = createNewIssue(repository, threadId, subject, from, body, attachmentSection);
@@ -218,23 +233,74 @@ public class MailProcessor {
         return from != null && from.toLowerCase().contains(botEmail.toLowerCase());
     }
 
-    private boolean isFromSecAlert(String from) {
-        return from != null && from.toLowerCase().contains(secAlertEmail.toLowerCase());
+    private boolean isFromSecAlert(String from, String replyTo) {
+        String needle = secAlertReplyTo.toLowerCase();
+        return Stream.of(from, replyTo)
+                .filter(Objects::nonNull)
+                .anyMatch(header -> header.toLowerCase().contains(needle));
     }
 
-    private Optional<GHIssue> resolveIssueBySecAlertThread(GitHub github, GHRepository repository, String threadId) {
+    private Optional<GHIssue> resolveIssueBySecAlertThreadId(GitHub github, GHRepository repository, String threadId) {
         try {
-            var query = "repo:%s \"%s %s\" is:issue in:comments".formatted(
-                    repositoryName, Constants.SECALERT_THREAD_ID_PREFIX, threadId);
+            var expectedMarker = Constants.SECALERT_THREAD_ID_PREFIX + " " + threadId;
+            var query = "repo:%s \"%s\" is:issue in:comments".formatted(repositoryName, expectedMarker);
             var iterator = github.searchIssues().q(query).list().iterator();
-            if (iterator.hasNext()) {
+            while (iterator.hasNext()) {
                 int issueNumber = iterator.next().getNumber();
-                return Optional.ofNullable(repository.getIssue(issueNumber));
+                var issue = repository.getIssue(issueNumber);
+                if (hasExactSecAlertThreadId(issue, expectedMarker)) {
+                    issueCache.put(threadId, issueNumber);
+                    return Optional.of(issue);
+                }
             }
         } catch (Exception e) {
-            LOGGER.warnf(e, "GitHub search failed for SecAlert thread %s", threadId);
+            LOGGER.warnf(e, "GitHub search by SecAlert-Thread-ID failed for thread %s", threadId);
         }
         return Optional.empty();
+    }
+
+    private boolean hasExactSecAlertThreadId(GHIssue issue, String expectedMarker) throws IOException {
+        for (GHIssueComment c : issue.queryComments().list()) {
+            String body = c.getBody();
+            if (body != null && body.contains(expectedMarker)) {
+                secAlertThreadIdCache.put(issue.getNumber(), Boolean.TRUE);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    Optional<GHIssue> resolveIssueByGhiTag(GHRepository repository, String subject) {
+        if (subject == null) return Optional.empty();
+        Matcher matcher = Constants.GHI_ISSUE_PATTERN.matcher(subject);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        int issueNumber = Integer.parseInt(matcher.group(1));
+        try {
+            return Optional.ofNullable(repository.getIssue(issueNumber));
+        } catch (IOException e) {
+            LOGGER.warnf(e, "Failed to fetch issue #%d referenced by SecAlert subject tag", issueNumber);
+            return Optional.empty();
+        }
+    }
+
+    void recordSecAlertThreadIdIfMissing(GHIssue issue, String threadId) throws IOException {
+        if (threadId == null || threadId.isBlank()) return;
+        int issueNumber = issue.getNumber();
+        if (Boolean.TRUE.equals(secAlertThreadIdCache.getIfPresent(issueNumber))) {
+            return;
+        }
+        for (GHIssueComment c : issue.queryComments().list()) {
+            String body = c.getBody();
+            if (body != null && body.contains(Constants.SECALERT_THREAD_ID_PREFIX)) {
+                secAlertThreadIdCache.put(issueNumber, Boolean.TRUE);
+                return;
+            }
+        }
+        issue.comment(Constants.SECALERT_THREAD_ID_PREFIX + " " + threadId);
+        secAlertThreadIdCache.put(issueNumber, Boolean.TRUE);
+        LOGGER.infof("Recorded %s %s on issue #%d", Constants.SECALERT_THREAD_ID_PREFIX, threadId, issueNumber);
     }
 
     void applyCveIdFromSecAlert(GHIssue issue, String subject, String body) throws IOException {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,7 +46,8 @@ google.group.target=keycloak-security@googlegroups.com
 # --- Google Group Target ---
 #Sync interval for checking e-mails
 bot.email.sync.interval=10m
-email.sender.secalert=secalert@redhat.com
+secalert.email.to=secalert@redhat.com
+secalert.email.reply-to=secalert@redhat.atlassian.net
 
 repository.mainRepository=keycloak/keycloak
 # For sensitive data the bot will only process emails and commands if installed on this repository

--- a/src/test/java/org/keycloak/gh/bot/AddTeamLabelToIssuesTest.java
+++ b/src/test/java/org/keycloak/gh/bot/AddTeamLabelToIssuesTest.java
@@ -16,7 +16,7 @@ public class AddTeamLabelToIssuesTest {
 
     @Test
     public void testTeamAdded() throws IOException {
-        verifyLabelAdded("area/oidc", "team/core-clients");
+        verifyLabelAdded("area/oidc", "team/core-protocols");
         verifyLabelAdded("area/organizations", "team/core-iam");
     }
 

--- a/src/test/java/org/keycloak/gh/bot/security/command/SecAlertCommandTest.java
+++ b/src/test/java/org/keycloak/gh/bot/security/command/SecAlertCommandTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -40,7 +41,8 @@ class SecAlertCommandTest {
         command = new SecAlertCommand();
 
         setField(command, "mailSender", mailSender);
-        setField(command, "secAlertEmail", "secalert@redhat.com");
+        setField(command, "secAlertTo", "secalert@redhat.com");
+        setField(command, "secAlertReplyTo", "secalert@redhat.atlassian.net");
         setField(command, "targetGroup", "keycloak-security@googlegroups.com");
 
         payload = mock(GHEventPayload.IssueComment.class);
@@ -59,21 +61,21 @@ class SecAlertCommandTest {
     // --- New thread (no existing SecAlert-Thread-ID) ---
 
     @Test
-    void newThread_sendsEmailWithSubjectAndPostsThreadId() throws Exception {
+    void newThread_sendsEmailWithGhiTaggedSubject() throws Exception {
         when(comment.getBody()).thenReturn("@security secalert CVE-2026-1234 XSS in admin console\n\nPlease triage this vulnerability.");
         setupSubject("CVE-2026-1234", "XSS", "in", "admin", "console");
         setupIssueComments("Some unrelated comment");
         setupIssueLabels(Status.TRIAGE.toLabel());
         when(issue.getTitle()).thenReturn("Wildcard Redirect URI vulnerability");
         when(mailSender.sendNewEmail("secalert@redhat.com", "keycloak-security@googlegroups.com",
-                "CVE-2026-1234 XSS in admin console", "Please triage this vulnerability."))
+                "CVE-2026-1234 XSS in admin console - #GHI-42", "Please triage this vulnerability."))
                 .thenReturn(Optional.of("19c48d1ecb33de98"));
 
         command.run(payload);
 
         verify(mailSender).sendNewEmail("secalert@redhat.com", "keycloak-security@googlegroups.com",
-                "CVE-2026-1234 XSS in admin console", "Please triage this vulnerability.");
-        verify(issue).comment("SecAlert email sent. " + Constants.SECALERT_THREAD_ID_PREFIX + " 19c48d1ecb33de98");
+                "CVE-2026-1234 XSS in admin console - #GHI-42", "Please triage this vulnerability.");
+        verify(issue, never()).comment(anyString());
         verify(issue).removeLabels(Status.TRIAGE.toLabel());
         verify(issue).addLabels(Status.CVE_REQUEST.toLabel());
         verify(issue).setTitle("[CVE-TBD] Wildcard Redirect URI vulnerability");
@@ -120,6 +122,7 @@ class SecAlertCommandTest {
         setupSubject("Race", "Condition");
         setupIssueComments();
         setupIssueLabels(Status.TRIAGE.toLabel());
+        when(issue.getTitle()).thenReturn("Some title");
 
         CountDownLatch emailBlocked = new CountDownLatch(1);
         CountDownLatch secondCallDone = new CountDownLatch(1);
@@ -133,11 +136,13 @@ class SecAlertCommandTest {
         SecAlertCommand secondCommand = new SecAlertCommand();
         secondCommand.unparsedArgs = new ArrayList<>(List.of("Race", "Condition"));
         setField(secondCommand, "mailSender", mailSender);
-        setField(secondCommand, "secAlertEmail", "secalert@redhat.com");
+        setField(secondCommand, "secAlertTo", "secalert@redhat.com");
+        setField(secondCommand, "secAlertReplyTo", "secalert@redhat.atlassian.net");
         setField(secondCommand, "targetGroup", "keycloak-security@googlegroups.com");
 
+        var firstThreadError = new java.util.concurrent.atomic.AtomicReference<Throwable>();
         Thread firstThread = new Thread(() -> {
-            try { command.run(payload); } catch (IOException e) { throw new RuntimeException(e); }
+            try { command.run(payload); } catch (Exception e) { firstThreadError.set(e); }
         });
         firstThread.start();
 
@@ -146,6 +151,7 @@ class SecAlertCommandTest {
         secondCallDone.countDown();
         firstThread.join(5000);
 
+        assertNull(firstThreadError.get(), "First thread threw an exception");
         verify(mailSender, times(1)).sendNewEmail(anyString(), anyString(), anyString(), anyString());
     }
 
@@ -176,16 +182,16 @@ class SecAlertCommandTest {
     // --- Reply on existing thread (SecAlert-Thread-ID found) ---
 
     @Test
-    void existingThread_repliesWithoutSubject() throws Exception {
+    void existingThread_repliesToSecAlertReplyToAddress() throws Exception {
         when(comment.getBody()).thenReturn("@security secalert\n\nThis is a follow-up reply.");
-        setupIssueComments("SecAlert email sent. " + Constants.SECALERT_THREAD_ID_PREFIX + " abc123def456");
-        when(mailSender.sendThreadedEmail("abc123def456", "secalert@redhat.com",
+        setupIssueComments(Constants.SECALERT_THREAD_ID_PREFIX + " abc123def456");
+        when(mailSender.sendThreadedEmail("abc123def456", "secalert@redhat.atlassian.net",
                 "keycloak-security@googlegroups.com", "This is a follow-up reply."))
                 .thenReturn(true);
 
         command.run(payload);
 
-        verify(mailSender).sendThreadedEmail("abc123def456", "secalert@redhat.com",
+        verify(mailSender).sendThreadedEmail("abc123def456", "secalert@redhat.atlassian.net",
                 "keycloak-security@googlegroups.com", "This is a follow-up reply.");
         verify(mailSender, never()).sendNewEmail(anyString(), anyString(), anyString(), anyString());
         verify(issue, never()).removeLabels(any(String[].class));
@@ -196,7 +202,7 @@ class SecAlertCommandTest {
     @Test
     void existingThread_reactsWithThumbsDownWhenReplyFails() throws Exception {
         when(comment.getBody()).thenReturn("@security secalert\n\nFailed reply.");
-        setupIssueComments("SecAlert email sent. " + Constants.SECALERT_THREAD_ID_PREFIX + " abc123");
+        setupIssueComments(Constants.SECALERT_THREAD_ID_PREFIX + " abc123");
         when(mailSender.sendThreadedEmail(anyString(), anyString(), anyString(), anyString())).thenReturn(false);
 
         command.run(payload);

--- a/src/test/java/org/keycloak/gh/bot/security/email/MailProcessorTest.java
+++ b/src/test/java/org/keycloak/gh/bot/security/email/MailProcessorTest.java
@@ -5,13 +5,24 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.keycloak.gh.bot.labels.Kind;
 import org.keycloak.gh.bot.labels.Status;
+import org.keycloak.gh.bot.security.common.Constants;
 import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueComment;
+import org.kohsuke.github.GHIssueCommentQueryBuilder;
 import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedIterable;
+import org.kohsuke.github.PagedIterator;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -167,5 +178,125 @@ public class MailProcessorTest {
 
         verify(issue).setTitle("[CVE-2026-8888] OIDC token leak");
         verify(issue, never()).addLabels(Kind.CVE.toLabel());
+    }
+
+    // --- resolveIssueByGhiTag ---
+
+    @Test
+    void resolveIssueByGhiTag_resolvesIssueFromSubjectTag() throws Exception {
+        GHRepository repository = mock(GHRepository.class);
+        GHIssue issue = mock(GHIssue.class);
+        when(repository.getIssue(42)).thenReturn(issue);
+
+        MailProcessor processor = new MailProcessor();
+        Optional<GHIssue> result = processor.resolveIssueByGhiTag(repository, "Re: CVE-2026-1234 XSS - #GHI-42");
+
+        assertTrue(result.isPresent());
+        assertEquals(issue, result.get());
+    }
+
+    @Test
+    void resolveIssueByGhiTag_returnsEmptyWhenNoTagPresent() {
+        GHRepository repository = mock(GHRepository.class);
+
+        MailProcessor processor = new MailProcessor();
+        Optional<GHIssue> result = processor.resolveIssueByGhiTag(repository, "Re: CVE-2026-1234 XSS in admin console");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void resolveIssueByGhiTag_returnsEmptyForNullSubject() {
+        GHRepository repository = mock(GHRepository.class);
+
+        MailProcessor processor = new MailProcessor();
+        Optional<GHIssue> result = processor.resolveIssueByGhiTag(repository, null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void resolveIssueByGhiTag_returnsEmptyWhenIssueFetchFails() throws Exception {
+        GHRepository repository = mock(GHRepository.class);
+        when(repository.getIssue(99)).thenThrow(new IOException("not found"));
+
+        MailProcessor processor = new MailProcessor();
+        Optional<GHIssue> result = processor.resolveIssueByGhiTag(repository, "Subject - #GHI-99");
+
+        assertTrue(result.isEmpty());
+    }
+
+    // --- recordSecAlertThreadIdIfMissing ---
+
+    @Test
+    void recordSecAlertThreadIdIfMissing_postsMarkerWhenAbsent() throws Exception {
+        GHIssue issue = mock(GHIssue.class);
+        when(issue.getNumber()).thenReturn(10);
+        stubIssueComments(issue, "Some unrelated comment");
+
+        MailProcessor processor = new MailProcessor();
+        processor.recordSecAlertThreadIdIfMissing(issue, "deadbeef123");
+
+        verify(issue).comment(Constants.SECALERT_THREAD_ID_PREFIX + " deadbeef123");
+    }
+
+    @Test
+    void recordSecAlertThreadIdIfMissing_skipsWhenMarkerAlreadyExists() throws Exception {
+        GHIssue issue = mock(GHIssue.class);
+        when(issue.getNumber()).thenReturn(10);
+        stubIssueComments(issue, Constants.SECALERT_THREAD_ID_PREFIX + " existingthread");
+
+        MailProcessor processor = new MailProcessor();
+        processor.recordSecAlertThreadIdIfMissing(issue, "newthread");
+
+        verify(issue, never()).comment(anyString());
+    }
+
+    @Test
+    void recordSecAlertThreadIdIfMissing_skipsOnBlankThreadId() throws Exception {
+        GHIssue issue = mock(GHIssue.class);
+
+        MailProcessor processor = new MailProcessor();
+        processor.recordSecAlertThreadIdIfMissing(issue, "");
+
+        verify(issue, never()).comment(anyString());
+        verify(issue, never()).queryComments();
+    }
+
+    @Test
+    void recordSecAlertThreadIdIfMissing_usesCache() throws Exception {
+        GHIssue issue = mock(GHIssue.class);
+        when(issue.getNumber()).thenReturn(10);
+        stubIssueComments(issue, Constants.SECALERT_THREAD_ID_PREFIX + " firstthread");
+
+        MailProcessor processor = new MailProcessor();
+        processor.recordSecAlertThreadIdIfMissing(issue, "secondthread");
+        processor.recordSecAlertThreadIdIfMissing(issue, "thirdthread");
+
+        verify(issue.queryComments(), org.mockito.Mockito.times(1)).list();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubIssueComments(GHIssue issue, String... commentBodies) throws IOException {
+        GHIssueCommentQueryBuilder queryBuilder = mock(GHIssueCommentQueryBuilder.class);
+        when(issue.queryComments()).thenReturn(queryBuilder);
+
+        List<GHIssueComment> comments = new ArrayList<>();
+        for (String body : commentBodies) {
+            GHIssueComment c = mock(GHIssueComment.class);
+            when(c.getBody()).thenReturn(body);
+            comments.add(c);
+        }
+
+        PagedIterable<GHIssueComment> pagedIterable = mock(PagedIterable.class);
+        when(queryBuilder.list()).thenReturn(pagedIterable);
+
+        when(pagedIterable.iterator()).thenAnswer(inv -> {
+            PagedIterator<GHIssueComment> pagedIterator = mock(PagedIterator.class);
+            final int[] index = {0};
+            when(pagedIterator.hasNext()).thenAnswer(i -> index[0] < comments.size());
+            when(pagedIterator.next()).thenAnswer(i -> comments.get(index[0]++));
+            return pagedIterator;
+        });
     }
 }


### PR DESCRIPTION
This commit fixes duplicate GitHub issue creation in keycloak-private when the bot receives SecAlert reply emails. The root cause: SecAlert replies arrive from a different email address than the one used for initial contact, and they use a different Gmail thread ID — so the bot couldn't correlate replies back to the original issue and created duplicates.

Current changes:

  1. #GHI-<number> subject tag — When sending the initial email to SecAlert, the bot now appends #GHI-42 to the subject line. SecAlert replies preserve this tag, giving the bot a reliable way to find the original issue by parsing the reply subject.
  2. SecAlert-Thread-ID recording — Instead of writing the thread ID marker immediately when sending, the bot now records it lazily when the first reply from secalert arrives. This captures SecAlert's thread ID (not ours), which is the one that actually appears in replies.
  3. Split email configuration — secalert.email.to (for initial outreach) vs. secalert.email.reply-to (for matching incoming replies), since SecAlert uses different addresses for inbound vs. outbound.

### AI Disclosure
This pull request contains code generated or assisted by Claude.

* Review: I have manually reviewed and verified every line of the AI-generated logic to ensure it adheres to Keycloak coding standards.
* Testing: I have validated these changes through local verification and confirmed they correctly address the issue.
* Accountability: I take full responsibility for this contribution and can explain the implementation details without further AI assistance.


Closes #69